### PR TITLE
feat: implement PKCS#8 as default format for RSA keys

### DIFF
--- a/lib/src/key_pair.dart
+++ b/lib/src/key_pair.dart
@@ -157,7 +157,7 @@ class KeyPair {
   static String _rsaPublicKeyToPem(pc.RSAPublicKey publicKey) {
     final pc.RSAPublicKey basicUtilsKey =
         RSAPublicKey(publicKey.modulus!, publicKey.exponent!);
-    return CryptoUtils.encodeRSAPublicKeyToPemPkcs1(basicUtilsKey);
+    return CryptoUtils.encodeRSAPublicKeyToPem(basicUtilsKey);
   }
 
   static String _rsaPrivateKeyToPem(pc.RSAPrivateKey privateKey) {
@@ -167,7 +167,7 @@ class KeyPair {
       privateKey.p,
       privateKey.q,
     );
-    return CryptoUtils.encodeRSAPrivateKeyToPemPkcs1(basicUtilsKey);
+    return CryptoUtils.encodeRSAPrivateKeyToPem(basicUtilsKey);
   }
 
   @override

--- a/test/blind_rsa_signatures_test.dart
+++ b/test/blind_rsa_signatures_test.dart
@@ -42,14 +42,14 @@ void main() {
         );
       });
 
-      test('should export and import PEM format', () {
+      test('should export and import PEM format (PKCS#8)', () {
         final publicKeyPem = keyPair.publicKeyPem;
         final privateKeyPem = keyPair.privateKeyPem;
 
-        expect(publicKeyPem, contains('-----BEGIN RSA PUBLIC KEY-----'));
-        expect(publicKeyPem, contains('-----END RSA PUBLIC KEY-----'));
-        expect(privateKeyPem, contains('-----BEGIN RSA PRIVATE KEY-----'));
-        expect(privateKeyPem, contains('-----END RSA PRIVATE KEY-----'));
+        expect(publicKeyPem, contains('-----BEGIN PUBLIC KEY-----'));
+        expect(publicKeyPem, contains('-----END PUBLIC KEY-----'));
+        expect(privateKeyPem, contains('-----BEGIN PRIVATE KEY-----'));
+        expect(privateKeyPem, contains('-----END PRIVATE KEY-----'));
 
         final restoredKeyPair = KeyPair.fromPem(
           publicKeyPem: publicKeyPem,
@@ -65,6 +65,8 @@ void main() {
       test('should blind messages successfully', () {
         final message = Uint8List.fromList('test message'.codeUnits);
         final blindingResult = publicKey.blind(null, message, true, options);
+        print(
+            'blindingResult.messageRandomizer: ${blindingResult.messageRandomizer}');
 
         expect(blindingResult.blindMessage, isA<Uint8List>());
         expect(blindingResult.secret, isA<Uint8List>());


### PR DESCRIPTION
- Update KeyPair class to generate PKCS#8 format keys by default
- Enhance SecretKey class to support both PKCS#8 and PKCS#1 formats
- Maintain backward compatibility with existing PKCS#1 keys
- Update tests to reflect new PKCS#8 default format
- All 38 tests now pass successfully

This change aligns the library with modern cryptographic standards while preserving compatibility with legacy key formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for importing RSA private keys in both PKCS#1 and PKCS#8 PEM formats.
- **Bug Fixes**
  - Updated key export to use PKCS#8 PEM format, ensuring better compatibility with standard tools.
- **Tests**
  - Clarified test case names and expected PEM headers/footers to reflect PKCS#8 format.
  - Added debug output for message randomizer in blinding tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->