### PR TITLE
Fix randomizer concat order to match Rust impl

### DIFF
--- a/lib/src/signature.dart
+++ b/lib/src/signature.dart
@@ -66,11 +66,11 @@ class Signature {
   Uint8List _prepareMessage(
       Uint8List message, Uint8List? messageRandomizer, Options options) {
     if (messageRandomizer != null) {
-      // Combine message with randomizer if present
+      // Combine randomizer with message
       final Uint8List combined =
-          Uint8List(message.length + messageRandomizer.length);
-      combined.setRange(0, message.length, message);
-      combined.setRange(message.length, combined.length, messageRandomizer);
+          Uint8List(messageRandomizer.length + message.length);
+      combined.setRange(0, messageRandomizer.length, messageRandomizer);
+      combined.setRange(messageRandomizer.length, combined.length, message);
       return _hashMessage(combined, options);
     } else {
       return _hashMessage(message, options);


### PR DESCRIPTION
The _prepareMessage method was concatenating message + randomizer, but the Rust blind-rsa-signatures library uses randomizer + message. This caused verification failures when Dart-generated signatures were verified by Rust implementations.

This change ensures compatibility between Dart and Rust versions of the blind RSA signatures library.

Fixes: Verification incompatibility with rust-blind-rsa-signatures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the order in which message and randomizer are combined during signature verification. This change does not affect the interface or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->